### PR TITLE
Updated Address.py->insert() + test_address.py

### DIFF
--- a/server/src/types/address.py
+++ b/server/src/types/address.py
@@ -24,7 +24,7 @@ class Address:
 
         # aid is primary key
         if 'aid' not in data:
-            raise ValueError('Cannot insert apartment without aid')
+            raise KeyError('Cannot insert apartment without aid')
         query.insert('addresses', data)
 
     @staticmethod

--- a/server/tst/types/test_address.py
+++ b/server/tst/types/test_address.py
@@ -5,27 +5,59 @@ import pytest
 
 
 class TestAddress:
-    def test_from_json(self):
+    @pytest.fixture
+    def address_from_json(self):
+        json = """{"aid":      "123",
+                   "building": "370 Jay St",
+                   "city":     "Brooklyn",
+                   "state":    "NY",
+                   "zipcode":  "11201"}"""
+        return Address.from_json(json)
+
+    @pytest.fixture
+    def address_from_raw_addr(self):
+        raw = "370 Jay St, Brooklyn, NY, 11201"
+        return Address.from_json(Address.process_raw_addr(raw))
+
+    @pytest.fixture
+    def address_to_dict(self):
+        return Address("123", "370 Jay St", "Brooklyn", "NY", "11201")
+
+    @pytest.fixture
+    def address_to_json_str(self):
+        address = Address("123", "370 Jay St", "Brooklyn", "NY", "11201")
+        json = '{"aid": "123", "building": "370 Jay St", "city": "Brooklyn", "state": "NY", "zipcode": "11201"}'  # noqa
+        return address, json
+
+    @pytest.fixture
+    def address_insert_noid(self):
+        return {"building": "370 Jay St", "city": "Brooklyn",
+                "state": "NY", "zipcode": "11201"}
+
+    @pytest.fixture
+    def address_insert_badtype(self):
+        return {1, 2, 3, 4}
+
+    def test_address_from_json(self, address_from_json):
         # Test with a valid json string
-        addr = Address.from_json('{"aid": "123", "building": "370 Jay St", "city": "Brooklyn", "state": "NY", "zipcode": "11201"}')  # noqa
+        addr = address_from_json
         assert addr.aid == "123"
         assert addr.building == "370 Jay St"
         assert addr.city == "Brooklyn"
         assert addr.state == "NY"
         assert addr.zipcode == "11201"
 
-    def test_from_raw_addr(self):
-        addr = Address.from_json(Address.process_raw_addr(
-            "370 Jay St, Brooklyn, NY, 11201"))
+    def test_address_from_raw_addr(self, address_from_raw_addr):
+        addr = address_from_raw_addr
         assert addr.building == "370 Jay St"
         assert addr.city == "Brooklyn"
         assert addr.state == "NY"
         assert addr.zipcode == "11201"
 
     # Test to_dict
-    def test_to_dict(self):
+    def test_address_to_dict(self, address_to_dict):
         # Test with a valid address
-        addr = Address("123", "370 Jay St", "Brooklyn", "NY", "11201")
+        addr = address_to_dict
         addr_dict = addr.to_dict()
         assert addr_dict["aid"] == "123"
         assert addr_dict["building"] == "370 Jay St"
@@ -34,28 +66,34 @@ class TestAddress:
         assert addr_dict["zipcode"] == "11201"
 
     # Test to_json_str
-    def test_to_json_str(self):
+    def test_address_to_json_str(self, address_to_json_str):
         # Test with a valid address
-        addr = Address("123", "370 Jay St", "Brooklyn", "NY", "11201")
+        addr, json = address_to_json_str
         data = addr.to_json_str()
-        assert data == '{"aid": "123", "building": "370 Jay St", "city": "Brooklyn", "state": "NY", "zipcode": "11201"}'  # noqa
 
-    def test_query(self):
+        assert data == json
+
+    def test_address_query(self):
         if os.getenv('CLOUD') == q.LOCAL:
             Address.insert({"aid": "123", "building": "370 Jay St",
                             "city": "Brooklyn", "state": "NY",
                             "zipcode": "11201"})
 
-            res = Address.find_all({})
+            res = Address.find_all()
             assert type(res) == list
 
-            res = Address.find_one({})
+            res = Address.find_one()
             assert type(res) == dict
 
-            q.delete_all('addresses', {})
+            q.delete_all('addresses')
 
-    def test_insert_fail(self):
+    def test_address_insert_noid(self, address_insert_noid):
+        with pytest.raises(KeyError):
+            data = address_insert_noid
+            Address.insert(data)
+
+    def test_address_insert_badtype(self, address_insert_badtype):
         with pytest.raises(ValueError):
-            data = {"building": "370 Jay St", "city": "Brooklyn",
-                    "state": "NY", "zipcode": "11201"}
+            data = address_insert_badtype
+            assert not isinstance(data, dict)
             Address.insert(data)


### PR DESCRIPTION
- Address.insert() now throws a KeyError if 'aid' is not found in data to insert.
- Restructured tests for test_address.py to include more pytest fixtures.
- Added an additional test to ensure that KeyError is thrown properly.